### PR TITLE
Bugfix - Remove Non Rrule Properties

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rrule",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "JavaScript library for working with recurrence rules for calendar dates.",
   "homepage": "http://jakubroztocil.github.io/rrule/",
   "keywords": [

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -2214,18 +2214,16 @@
      * @param {String} s A string containing the set of recurrence properties.
      * @return {String}  A filtered string containing the set of recurrence properties without floating timezones.
      */
-    filterFloatingTimezones: function (s) {
+    filterFloatingTimezones: function (stringRule) {
       // Uses a regex to split the recurrence string by carriage return.
-      var parsedRecurrenceString = s.split(/\s+/)
+      var parsedRecurrenceString = stringRule.split(/\s+/)
 
       // Remove any of the recurrence date properties that contain floating timezone properties.
       parsedRecurrenceString.forEach(function (ruleString) {
-        var index = parsedRecurrenceString.indexOf(ruleString);
+        var rruleIndex = parsedRecurrenceString.indexOf(ruleString);
 
-        if (contains(ruleString, 'TZID')) {
-          if (index !== -1) {
-            parsedRecurrenceString.splice(index, 1)
-          }
+        if (contains(ruleString, 'TZID') && rruleIndex !== -1) {
+          parsedRecurrenceString.splice(rruleIndex, 1)
         }
       })
 
@@ -2240,7 +2238,7 @@
       var defaultKeys = Object.keys(RRuleStr.DEFAULT_OPTIONS)
 
       // Sets the recurrence string to the original recurrence model without any floating timezones.
-      s = this.filterFloatingTimezones(s)
+      filteredRecurrenceString = this.filterFloatingTimezones(s)
 
       keys.forEach(function (key) {
         if (!contains(defaultKeys, key)) invalid.push(key)
@@ -2253,7 +2251,7 @@
         if (!contains(keys, key)) options[key] = RRuleStr.DEFAULT_OPTIONS[key]
       })
 
-      return this._parseRfc(s, options)
+      return this._parseRfc(filteredRecurrenceString, options)
     }
   }
 

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -2219,7 +2219,7 @@
      */
     filterFloatingTimezones: function (stringRule) {
       // Uses a regex to split the recurrence string by carriage return.
-      var parsedRecurrenceString = stringRule.split(/\s+/)
+      var parsedRecurrenceString = stringRule.split(/[\n\r]/)
 
       // Remove any of the recurrence date properties that contain floating timezone properties.
       parsedRecurrenceString.forEach(function (ruleString) {

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -2241,7 +2241,7 @@
       var defaultKeys = Object.keys(RRuleStr.DEFAULT_OPTIONS)
 
       // Sets the recurrence string to the original recurrence model without any floating timezones.
-      filteredRecurrenceString = this.filterFloatingTimezones(s)
+      var filteredRecurrenceString = this.filterFloatingTimezones(s)
 
       keys.forEach(function (key) {
         if (!contains(defaultKeys, key)) invalid.push(key)

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -2153,7 +2153,7 @@
             for (j = 0; j < parms.length; j++) {
               parm = parms[j]
               if (parm !== 'VALUE=DATE-TIME') {
-                throw new Error('unsupported RDATE parm: ' + parm)
+                throw new Error('unsupported EXDATE parm: ' + parm)
               }
             }
             exdatevals.push(value)
@@ -2209,12 +2209,38 @@
       }
     },
 
+    /**
+     * Filters out floating timezone properties.
+     * @param {String} s A string containing the set of recurrence properties.
+     * @return {String}  A filtered string containing the set of recurrence properties without floating timezones.
+     */
+    filterFloatingTimezones: function (s) {
+      // Uses a regex to split the recurrence string by carriage return.
+      var parsedRecurrenceString = s.split(/\s+/)
+
+      // Remove any of the recurrence date properties that contain floating timezone properties.
+      parsedRecurrenceString.forEach(function (ruleString) {
+        var index = parsedRecurrenceString.indexOf(ruleString);
+
+        if (contains(ruleString, 'TZID')) {
+          if (index !== -1) {
+            parsedRecurrenceString.splice(index, 1)
+          }
+        }
+      })
+
+      return parsedRecurrenceString.join('\n')
+    },
+
     parse: function (s, options) {
       options = options || {}
 
       var invalid = []
       var keys = Object.keys(options)
       var defaultKeys = Object.keys(RRuleStr.DEFAULT_OPTIONS)
+
+      // Sets the recurrence string to the original recurrence model without any floating timezones.
+      s = this.filterFloatingTimezones(s)
 
       keys.forEach(function (key) {
         if (!contains(defaultKeys, key)) invalid.push(key)

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -2223,7 +2223,7 @@
 
       // Remove any of the recurrence date properties that contain floating timezone properties.
       parsedRecurrenceString.forEach(function (ruleString) {
-        var rruleIndex = parsedRecurrenceString.indexOf(ruleString);
+        var rruleIndex = parsedRecurrenceString.indexOf(ruleString)
 
         if (contains(ruleString, 'TZID') && rruleIndex !== -1) {
           parsedRecurrenceString.splice(rruleIndex, 1)

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -2219,13 +2219,14 @@
      */
     filterFloatingTimezones: function (stringRule) {
       // Uses a regex to split the recurrence string by carriage return.
-      var parsedRecurrenceString = stringRule.split(/[\n\r]/)
+      var newline = /[\n\r]/;
+      var parsedRecurrenceString = stringRule.split(newline)
 
       // Remove any of the recurrence date properties that contain floating timezone properties.
-      parsedRecurrenceString.forEach(function (ruleString) {
+      parsedRecurrenceString.slice(0).forEach(function (ruleString) {
         var rruleIndex = parsedRecurrenceString.indexOf(ruleString)
 
-        if (contains(ruleString, 'TZID') && rruleIndex !== -1) {
+        if (!contains(ruleString, 'RRULE') && rruleIndex !== -1) {
           parsedRecurrenceString.splice(rruleIndex, 1)
         }
       })

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -2211,6 +2211,8 @@
 
     /**
      * Filters out floating timezone properties.
+     * See https://tools.ietf.org/html/rfc5545#section-3.2.19 for more on the time zone property part of the iCal spec.
+     * See https://tools.ietf.org/html/rfc5545#section-3.3.5 for more on floating times in the iCal spec.
      * @param {String} stringRule A string containing the set of recurrence properties.
      * @return {String}           A filtered string containing the set of recurrence properties without floating
      *                            timezones.

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -2211,8 +2211,9 @@
 
     /**
      * Filters out floating timezone properties.
-     * @param {String} s A string containing the set of recurrence properties.
-     * @return {String}  A filtered string containing the set of recurrence properties without floating timezones.
+     * @param {String} stringRule A string containing the set of recurrence properties.
+     * @return {String}           A filtered string containing the set of recurrence properties without floating
+     *                            timezones.
      */
     filterFloatingTimezones: function (stringRule) {
       // Uses a regex to split the recurrence string by carriage return.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrule",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "JavaScript library for working with recurrence rules for calendar dates.",
   "homepage": "http://jakubroztocil.github.io/rrule/",
   "keywords": [


### PR DESCRIPTION
### Overview

This fix removes the error that happens when editing floating time. Unfortunately, the way the library is set up, makes it very hard to decorate the library. Instead forked the latest version with proper fixes. 

The way this works is we take the set of main recurrence properties by string, and remove anything that is not an `RRULE`.


### Changelog

- Creates a private function that matches for `RRUL`E and removes any other recurrence properties
- Fixes typo where it says `unsupported RDATE parm` for `EXDATE`, as it was confusing when debugging


![recurrence_irl](https://media.giphy.com/media/xT5LMHjKqPYWeeVpAc/giphy.gif)
